### PR TITLE
Added command to spectate on player index

### DIFF
--- a/CastingEssentials/Modules/CameraTools.cpp
+++ b/CastingEssentials/Modules/CameraTools.cpp
@@ -53,6 +53,7 @@ CameraTools::CameraTools()
 
 	m_TPLockBone = new ConVar("ce_tplock_bone", "bip_spine_2", FCVAR_NONE, "Bone to attach camera position to. Enable developer 2 for associated warnings.");
 
+	m_SpecIndex = new ConCommand("ce_cameratools_spec_index", [](const CCommand& args) { GetModule()->SpecIndex(args); }, "Spectates a specific player index");
 	m_SpecPosition = new ConCommand("ce_cameratools_spec_pos", [](const CCommand& args) { GetModule()->SpecPosition(args); }, "Moves the camera to a given position and angle.");
 	m_SpecPositionDelta = new ConCommand("ce_cameratools_spec_pos_delta", [](const CCommand& args) { GetModule()->SpecPositionDelta(args); }, "Offsets the camera by the given values.");
 
@@ -339,6 +340,26 @@ void CameraTools::SpecClass(TFTeam team, TFClassType playerClass, int classIndex
 		classIndex = 0;
 
 	SpecPlayer(validPlayers[classIndex]->GetEntity()->entindex());
+}
+
+void CameraTools::SpecIndex(const CCommand& command)
+{
+	if (command.ArgC() != 2)
+	{
+		PluginWarning("%s: Expected 1 argument\n", m_SpecIndex->GetName());
+		PluginWarning("Usage: %s\n", m_SpecClass->GetHelpText());
+		return;
+	}
+
+	if (!IsInteger(command.Arg(1)))
+	{
+		PluginWarning("%s: player index \"%s\" is not an integer\n", m_SpecClass->GetName(), command.Arg(1));
+		PluginWarning("Usage: %s\n", m_SpecClass->GetHelpText());
+		return;
+	}
+
+	auto idx = atoi(command.Arg(1));
+	SpecPlayer(idx);
 }
 
 void CameraTools::SpecPlayer(int playerIndex)

--- a/CastingEssentials/Modules/CameraTools.h
+++ b/CastingEssentials/Modules/CameraTools.h
@@ -61,6 +61,7 @@ private:
 	ConVar* m_NextPlayerMode;
 	ConCommand* m_SpecClass;
 	ConCommand* m_SpecSteamID;
+	ConCommand* m_SpecIndex;
 
 	ConCommand* m_ShowUsers;
 	void ShowUsers(const CCommand& command);
@@ -77,6 +78,7 @@ private:
 	void SpecClass(const CCommand& command);
 	void SpecClass(TFTeam team, TFClassType playerClass, int classIndex);
 	void SpecSteamID(const CCommand& command);
+	void SpecIndex(const CCommand& command);
 
 	void SpecPlayer(int playerIndex);
 


### PR DESCRIPTION
Useful when player entity index is known, e.g. when game is controlled
remotely.