### PR TITLE
Added ClientTools plugin

### DIFF
--- a/CastingEssentials/CastingEssentials.vcxproj
+++ b/CastingEssentials/CastingEssentials.vcxproj
@@ -94,6 +94,7 @@
     <ClCompile Include="Hooking\IGroupHook.cpp" />
     <ClCompile Include="Misc\DebugOverlay.cpp" />
     <ClCompile Include="Misc\OffsetChecking.cpp" />
+    <ClCompile Include="Modules\ClientTools.cpp" />
     <ClCompile Include="Modules\HitEvents.cpp" />
     <ClCompile Include="Modules\HUDHacking.cpp" />
     <ClCompile Include="Misc\MissingDefinitions.cpp" />
@@ -150,6 +151,7 @@
     <ClInclude Include="Misc\DebugOverlay.h" />
     <ClInclude Include="Misc\Extras\VPlane.h" />
     <ClInclude Include="Misc\HLTVCameraHack.h" />
+    <ClInclude Include="Modules\clienttools.h" />
     <ClInclude Include="Modules\HitEvents.h" />
     <ClInclude Include="Modules\HUDHacking.h" />
     <ClInclude Include="Modules\Antifreeze.h" />

--- a/CastingEssentials/CastingEssentials.vcxproj
+++ b/CastingEssentials/CastingEssentials.vcxproj
@@ -151,7 +151,7 @@
     <ClInclude Include="Misc\DebugOverlay.h" />
     <ClInclude Include="Misc\Extras\VPlane.h" />
     <ClInclude Include="Misc\HLTVCameraHack.h" />
-    <ClInclude Include="Modules\clienttools.h" />
+    <ClInclude Include="Modules\ClientTools.h" />
     <ClInclude Include="Modules\HitEvents.h" />
     <ClInclude Include="Modules\HUDHacking.h" />
     <ClInclude Include="Modules\Antifreeze.h" />

--- a/CastingEssentials/CastingEssentials.vcxproj.filters
+++ b/CastingEssentials/CastingEssentials.vcxproj.filters
@@ -320,7 +320,7 @@
     <ClInclude Include="Modules\HitEvents.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Modules\clienttools.h">
+    <ClInclude Include="Modules\ClientTools.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/CastingEssentials/CastingEssentials.vcxproj.filters
+++ b/CastingEssentials/CastingEssentials.vcxproj.filters
@@ -150,6 +150,9 @@
     <ClCompile Include="Modules\HitEvents.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\ClientTools.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="PluginBase\Plugin.h">
@@ -315,6 +318,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Modules\HitEvents.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\clienttools.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/CastingEssentials/Modules/ClientTools.cpp
+++ b/CastingEssentials/Modules/ClientTools.cpp
@@ -1,0 +1,67 @@
+#include "Modules/ClientTools.h"
+#include "PluginBase/HookManager.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+bool ClientTools::CheckDependencies() {
+	return true;
+}
+
+HWND GetMainWindow()
+{
+	class IGame
+	{
+	public:
+		virtual     ~IGame(void) { }
+		virtual bool  Init(void *pvInstance) = 0;
+		virtual bool  Shutdown(void) = 0;
+		virtual bool  CreateGameWindow(void) = 0;
+		virtual void  DestroyGameWindow(void) = 0;
+		virtual void  SetGameWindow(void* hWnd) = 0;
+		virtual bool  InputAttachToGameWindow() = 0;
+		virtual void  InputDetachFromGameWindow() = 0;
+		virtual void  PlayStartupVideos(void) = 0;
+		virtual void* GetMainWindow(void) = 0;
+		virtual void**  GetMainWindowAddress(void) = 0;
+		virtual void  GetDesktopInfo(int &width, int &height, int &refreshrate) = 0;
+		virtual void  SetWindowXY(int x, int y) = 0;
+		virtual void  SetWindowSize(int w, int h) = 0;
+		virtual void  GetWindowRect(int *x, int *y, int *w, int *h) = 0;
+		virtual bool  IsActiveApp(void) = 0;
+		virtual void  DispatchAllStoredGameMessages() = 0;
+	};
+
+	static IGame* g_pGame{ nullptr };
+
+	if (!g_pGame)
+	{
+		constexpr auto SIG = "\x55\x8B\xEC\x83\xEC\x14\x8B\x0D\x00\x00\x00\x00\xC7\x45\xEC\x14\x00\x00\x00\x8B\x01\xFF\x50\x24\x89\x45\xF0\x8D\x45\xEC\x50\xC7\x45\xF4\x03\x00\x00\x00\xC7\x45\xF8\x05\x00\x00\x00\xC7\x45\xFC\x00\x00\x00\x00\xFF\x15\x00\x00\x00\x00\x8B\xE5\x5D\xC3";
+		constexpr auto MASK = "xxxxxxxx????xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx????xxxx";
+		constexpr auto OFFSET = 8;
+
+		auto target = (IGame***)((char*)SignatureScan("engine", SIG, MASK) + OFFSET);
+		if ((int)target == OFFSET) {
+			throw bad_pointer("CGame");
+		}
+		g_pGame = **target;
+	}
+	return (HWND)g_pGame->GetMainWindow();
+}
+
+void ClientTools::UpdateWindowTitle(const char* oldval) {
+	auto newval = cv_windowtitle.GetString();
+	if (strlen(newval) == 0) {
+		if (strlen(oldval) != 0) {
+			SetWindowText(GetMainWindow(), origtitle.c_str());
+		}
+	}
+	else {
+		if (origtitle.empty()) {
+			char buf[256] = { 0 };
+			GetWindowText(GetMainWindow(), buf, sizeof(buf));
+			origtitle = buf;
+		}
+		SetWindowText(GetMainWindow(), newval);
+	}
+}

--- a/CastingEssentials/Modules/ClientTools.h
+++ b/CastingEssentials/Modules/ClientTools.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "PluginBase/Modules.h"
+
+#include <convar.h>
+
+class ClientTools : public Module<ClientTools>
+{
+public:
+	static ClientTools* GetModule() { return Modules().GetModule<ClientTools>(); }
+	static const char* GetModuleName() { return Modules().GetModuleName<ClientTools>().c_str(); }
+
+	static bool CheckDependencies();
+private:
+
+	void UpdateWindowTitle(const char* oldval);
+	ConVar cv_windowtitle{ "ce_clienttools_windowtitle", "", FCVAR_NONE, "Overrides the game window title", [](IConVar* var, const char* oldval, float foldval) { GetModule()->UpdateWindowTitle(oldval); } };
+	std::string origtitle;
+};

--- a/CastingEssentials/PluginBase/CastingPlugin.cpp
+++ b/CastingEssentials/PluginBase/CastingPlugin.cpp
@@ -29,6 +29,7 @@
 #include "Modules/ProjectileOutlines.h"
 #include "Modules/SteamTools.h"
 #include "Modules/TeamNames.h"
+#include "Modules/ClientTools.h"
 
 const char* const PLUGIN_VERSION_ID = "r17 beta3";
 const char* const PLUGIN_FULL_VERSION = strdup(strprintf("%s %s", PLUGIN_NAME, PLUGIN_VERSION_ID).c_str());
@@ -88,6 +89,7 @@ bool CastingPlugin::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn g
 	Modules().RegisterAndLoadModule<ProjectileOutlines>("Projectile Outlines");
 	Modules().RegisterAndLoadModule<SteamTools>("Steam Tools");
 	Modules().RegisterAndLoadModule<TeamNames>("Team Names");
+	Modules().RegisterAndLoadModule<ClientTools>("Client Tools");
 
 	ConVar_Register();
 


### PR DESCRIPTION
Currently provides a command for overriding the game client window
title. Useful when running multiple instances and matching their window
title in e.g. OBS Studio.