### PR TITLE
Add `_X86_` define to Shared props.

### DIFF
--- a/CastingEssentials/Properties/Shared.props
+++ b/CastingEssentials/Properties/Shared.props
@@ -15,7 +15,7 @@
     </Link>
     <ClCompile>
       <TreatSpecificWarningsAsErrors>4715;4717;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
-      <PreprocessorDefinitions>SUPPRESS_INVALID_PARAMETER_NO_INFO;VERSION_SAFE_STEAM_API_INTERFACES;CLIENT_DLL;WIN32;RAD_TELEMETRY_DISABLED;TF2_SDK;TF_CLIENT_DLL;NO_PCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SUPPRESS_INVALID_PARAMETER_NO_INFO;VERSION_SAFE_STEAM_API_INTERFACES;CLIENT_DLL;WIN32;RAD_TELEMETRY_DISABLED;TF2_SDK;TF_CLIENT_DLL;NO_PCH;_X86_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedIncludeFiles>$(ProjectDir)PluginBase\Common.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <DisableSpecificWarnings>4594;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
Apparently the `Microsoft.Cpp.Win32.user` propsheet does not always
define `_X86_` on new MSVC installations. Since TF2 is always x86
anyway, we'll just define it.

This fixes a `No Target Architecture` compilation error when compiling
units depending on `Windows.h`