### PR TITLE
Refactor module loading

### DIFF
--- a/CastingEssentials/Modules/Antifreeze.cpp
+++ b/CastingEssentials/Modules/Antifreeze.cpp
@@ -10,6 +10,8 @@
 #include <vgui_controls/Panel.h>
 #include <vprof.h>
 
+MODULE_REGISTER(AntiFreeze);
+
 class AntiFreeze::Panel : public vgui::Panel
 {
 public:

--- a/CastingEssentials/Modules/Antifreeze.h
+++ b/CastingEssentials/Modules/Antifreeze.h
@@ -12,6 +12,7 @@ public:
 	AntiFreeze();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "HUD Antifreeze"; }
 
 private:
 	class Panel;

--- a/CastingEssentials/Modules/AutoCameras.cpp
+++ b/CastingEssentials/Modules/AutoCameras.cpp
@@ -29,6 +29,8 @@
 #include <regex>
 #include <sstream>
 
+MODULE_REGISTER(AutoCameras);
+
 #undef min
 #undef max
 

--- a/CastingEssentials/Modules/AutoCameras.h
+++ b/CastingEssentials/Modules/AutoCameras.h
@@ -14,6 +14,7 @@ class AutoCameras final : public Module<AutoCameras>
 {
 public:
 	AutoCameras();
+	static constexpr __forceinline const char* GetModuleName() { return "AutoCameras"; }
 
 	void OnTick(bool ingame) override;
 

--- a/CastingEssentials/Modules/CameraAutoSwitch.cpp
+++ b/CastingEssentials/Modules/CameraAutoSwitch.cpp
@@ -25,6 +25,8 @@
 #include <vgui/IVGui.h>
 #include <vprof.h>
 
+MODULE_REGISTER(CameraAutoSwitch);
+
 CameraAutoSwitch::CameraAutoSwitch() :
 	ce_cameraautoswitch_enabled("ce_cameraautoswitch_enabled", "0", FCVAR_NONE, "enable automatic switching of camera"),
 

--- a/CastingEssentials/Modules/CameraAutoSwitch.h
+++ b/CastingEssentials/Modules/CameraAutoSwitch.h
@@ -12,6 +12,7 @@ public:
 	virtual ~CameraAutoSwitch();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Camera Auto-Switch"; }
 
 private:
 	ConVar ce_cameraautoswitch_enabled;

--- a/CastingEssentials/Modules/CameraSmooths.cpp
+++ b/CastingEssentials/Modules/CameraSmooths.cpp
@@ -22,6 +22,8 @@
 #undef max
 #include <algorithm>
 
+MODULE_REGISTER(CameraSmooths);
+
 CameraSmooths::CameraSmooths() :
 	ce_smoothing_enabled("ce_smoothing_enabled", "0", FCVAR_NONE, "Enables smoothing between spectator targets."),
 	ce_smoothing_fov("ce_smoothing_fov", "45", FCVAR_NONE, "Only targets within this FOV will be smoothed to.", true, 0, true, 180),
@@ -55,6 +57,8 @@ CameraSmooths::CameraSmooths() :
 
 bool CameraSmooths::CheckDependencies()
 {
+	Modules().Depend<CameraState>();
+
 	bool ready = true;
 
 	if (!Interfaces::GetClientEngineTools())

--- a/CastingEssentials/Modules/CameraSmooths.h
+++ b/CastingEssentials/Modules/CameraSmooths.h
@@ -19,6 +19,7 @@ public:
 	CameraSmooths();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Camera Smooths"; }
 
 	bool IsSmoothing() const { return m_InProgress; }
 private:

--- a/CastingEssentials/Modules/CameraState.cpp
+++ b/CastingEssentials/Modules/CameraState.cpp
@@ -12,6 +12,8 @@
 #undef min
 #undef max
 
+MODULE_REGISTER(CameraState);
+
 CameraState::CameraState() :
 	m_InToolModeHook(std::bind(&CameraState::InToolModeOverride, this)),
 	m_IsThirdPersonCameraHook(std::bind(&CameraState::IsThirdPersonCameraOverride, this)),

--- a/CastingEssentials/Modules/CameraState.h
+++ b/CastingEssentials/Modules/CameraState.h
@@ -13,6 +13,7 @@ class CameraState final : public Module<CameraState>
 {
 public:
 	CameraState();
+	static constexpr __forceinline const char* GetModuleName() { return "Camera State"; }
 
 	const Vector& GetLastFramePluginViewOrigin() const { return m_LastFramePluginView.m_Origin; }
 	const QAngle& GetLastFramePluginViewAngles() const { return m_LastFramePluginView.m_Angles; }

--- a/CastingEssentials/Modules/CameraState.h
+++ b/CastingEssentials/Modules/CameraState.h
@@ -9,6 +9,8 @@ class C_BaseEntity;
 enum ObserverMode;
 class Player;
 
+#include "ClientTools.h"
+
 class CameraState final : public Module<CameraState>
 {
 public:

--- a/CastingEssentials/Modules/CameraTools.cpp
+++ b/CastingEssentials/Modules/CameraTools.cpp
@@ -26,6 +26,8 @@
 
 #include <algorithm>
 
+MODULE_REGISTER(CameraTools);
+
 EntityOffset<float> CameraTools::s_ViewOffsetZOffset;
 
 CameraTools::CameraTools() :
@@ -98,6 +100,8 @@ CameraTools::CameraTools() :
 
 bool CameraTools::CheckDependencies()
 {
+	Modules().Depend<CameraState>();
+
 	bool ready = true;
 
 	if (!Interfaces::GetEngineTool())

--- a/CastingEssentials/Modules/CameraTools.h
+++ b/CastingEssentials/Modules/CameraTools.h
@@ -34,6 +34,7 @@ public:
 	virtual ~CameraTools() = default;
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Camera Tools"; }
 
 	void SpecPosition(const Vector& pos, const QAngle& angle, ObserverMode mode = OBS_MODE_FIXED, float fov = -1);
 

--- a/CastingEssentials/Modules/ClientTools.cpp
+++ b/CastingEssentials/Modules/ClientTools.cpp
@@ -4,6 +4,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+MODULE_REGISTER(ClientTools);
+
 ClientTools::ClientTools() :
 	ce_clienttools_windowtitle("ce_clienttools_windowtitle", "", FCVAR_NONE, "Overrides the game window title",
 		[](IConVar* var, const char* oldval, float foldval) { GetModule()->UpdateWindowTitle(oldval); })
@@ -50,6 +52,8 @@ HWND GetMainWindow()
 	}
 	return (HWND)g_pGame->GetMainWindow();
 }
+
+#include "CameraTools.h"
 
 bool ClientTools::CheckDependencies()
 {

--- a/CastingEssentials/Modules/ClientTools.h
+++ b/CastingEssentials/Modules/ClientTools.h
@@ -10,6 +10,7 @@ public:
 	ClientTools();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Client Tools"; }
 
 private:
 	void UpdateWindowTitle(const char* oldval);

--- a/CastingEssentials/Modules/ConsoleTools.cpp
+++ b/CastingEssentials/Modules/ConsoleTools.cpp
@@ -13,6 +13,8 @@
 #undef min
 #undef max
 
+MODULE_REGISTER(ConsoleTools);
+
 class ConsoleTools::PauseFilter final
 {
 public:

--- a/CastingEssentials/Modules/ConsoleTools.h
+++ b/CastingEssentials/Modules/ConsoleTools.h
@@ -13,6 +13,7 @@ public:
 	ConsoleTools();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Console Tools"; }
 
 private:
 	void ConsoleColorPrintfHook(const Color& color, const char* msg);

--- a/CastingEssentials/Modules/FOVOverride.cpp
+++ b/CastingEssentials/Modules/FOVOverride.cpp
@@ -14,6 +14,8 @@
 #include "Modules/CameraState.h"
 #include "Modules/CameraTools.h"
 
+MODULE_REGISTER(FOVOverride);
+
 FOVOverride::FOVOverride() :
 	ce_fovoverride_firstperson("ce_fovoverride_firstperson", "90"),
 	ce_fovoverride_thirdperson("ce_fovoverride_thirdperson", "90"),

--- a/CastingEssentials/Modules/FOVOverride.h
+++ b/CastingEssentials/Modules/FOVOverride.h
@@ -15,6 +15,7 @@ public:
 	FOVOverride();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "FOV Override"; }
 
 	float GetBaseFOV(ObserverMode mode) const;
 

--- a/CastingEssentials/Modules/FreezeInfo.cpp
+++ b/CastingEssentials/Modules/FreezeInfo.cpp
@@ -10,6 +10,8 @@
 #include "PluginBase/HookManager.h"
 #include "PluginBase/Interfaces.h"
 
+MODULE_REGISTER(FreezeInfo);
+
 class FreezeInfo::Panel : public vgui::EditablePanel
 {
 public:

--- a/CastingEssentials/Modules/FreezeInfo.h
+++ b/CastingEssentials/Modules/FreezeInfo.h
@@ -11,6 +11,7 @@ public:
 	FreezeInfo();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Freeze Info"; }
 
 private:
 	void OnTick(bool inGame) override;

--- a/CastingEssentials/Modules/Graphics.cpp
+++ b/CastingEssentials/Modules/Graphics.cpp
@@ -28,6 +28,8 @@
 #undef min
 #undef max
 
+MODULE_REGISTER(Graphics);
+
 EntityOffset<EHANDLE> Graphics::s_MoveParent;
 EntityTypeChecker Graphics::s_TFViewModelType;
 

--- a/CastingEssentials/Modules/Graphics.h
+++ b/CastingEssentials/Modules/Graphics.h
@@ -29,6 +29,7 @@ public:
 	const ConVar& GetDebugGlowConVar() const { return ce_graphics_debug_glow; }
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Graphics Enhancements"; }
 
 protected:
 	void OnTick(bool inGame) override;

--- a/CastingEssentials/Modules/HUDHacking.cpp
+++ b/CastingEssentials/Modules/HUDHacking.cpp
@@ -22,6 +22,8 @@
 #undef min
 #undef max
 
+MODULE_REGISTER(HUDHacking);
+
 EntityOffset<float> HUDHacking::s_RageMeter;
 
 ConVar HUDHacking::ce_hud_debug_unassociated_playerpanels("ce_hud_debug_unassociated_playerpanels", "0", FCVAR_NONE, "Print debug messages to the console when a player cannot be found for a given playerpanel.");

--- a/CastingEssentials/Modules/HUDHacking.h
+++ b/CastingEssentials/Modules/HUDHacking.h
@@ -22,6 +22,7 @@ public:
 	HUDHacking();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Evil HUD Modifications"; }
 
 	static vgui::VPANEL GetSpecGUI();
 	static Player* GetPlayerFromPanel(vgui::EditablePanel* playerPanel);

--- a/CastingEssentials/Modules/HitEvents.cpp
+++ b/CastingEssentials/Modules/HitEvents.cpp
@@ -14,6 +14,8 @@
 
 #include <sstream>
 
+MODULE_REGISTER(HitEvents);
+
 HitEvents::HitEvents() :
 	ce_hitevents_enabled("ce_hitevents_enabled", "0", FCVAR_NONE, "Enables hitsounds and damage numbers in STVs.",
 		[](IConVar* var, const char* oldValue, float fOldValue) { GetModule()->UpdateEnabledState(); }),

--- a/CastingEssentials/Modules/HitEvents.h
+++ b/CastingEssentials/Modules/HitEvents.h
@@ -23,6 +23,7 @@ public:
 	virtual ~HitEvents();
 
 	static bool CheckDependencies() { return true; }
+	static constexpr __forceinline const char* GetModuleName() { return "Player Hit Events"; }
 
 protected:
 	void FireGameEvent(IGameEvent* event) override;

--- a/CastingEssentials/Modules/IngameTeamScores.cpp
+++ b/CastingEssentials/Modules/IngameTeamScores.cpp
@@ -8,6 +8,8 @@
 #include <vgui/IVGui.h>
 #include <vgui_controls/EditablePanel.h>
 
+MODULE_REGISTER(IngameTeamScores);
+
 class IngameTeamScores::ScorePanel : public vgui::EditablePanel
 {
 	DECLARE_CLASS_SIMPLE(ScorePanel, vgui::EditablePanel);

--- a/CastingEssentials/Modules/IngameTeamScores.h
+++ b/CastingEssentials/Modules/IngameTeamScores.h
@@ -8,6 +8,7 @@ class IngameTeamScores final : public Module<IngameTeamScores>
 {
 public:
 	IngameTeamScores();
+	static constexpr __forceinline const char* GetModuleName() { return "Ingame Team Scores"; }
 
 private:
 	void ReloadSettings();

--- a/CastingEssentials/Modules/ItemSchema.cpp
+++ b/CastingEssentials/Modules/ItemSchema.cpp
@@ -12,6 +12,8 @@
 #undef min
 #undef max
 
+MODULE_REGISTER(ItemSchema);
+
 ItemSchema::ItemSchema() :
 	ce_itemschema_print("ce_itemschema_print", []() { GetModule()->PrintAliases(); }, "Prints the current state of the item schema module."),
 	ce_itemschema_reload("ce_itemschema_reload", []() { GetModule()->LoadItemSchema(); }, "Reloads the item schema module.")

--- a/CastingEssentials/Modules/ItemSchema.h
+++ b/CastingEssentials/Modules/ItemSchema.h
@@ -20,6 +20,7 @@ public:
 	ItemSchema();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Item Schema"; }
 
 	// Converts a "specialized" version of an item (a botkiller medigun, for example) into its
 	// "base" item (a stock medigun)

--- a/CastingEssentials/Modules/Killfeed.cpp
+++ b/CastingEssentials/Modules/Killfeed.cpp
@@ -10,6 +10,8 @@
 #include <locale>
 #include <codecvt>
 
+MODULE_REGISTER(Killfeed);
+
 Killfeed::Killfeed() :
 	ce_killfeed_continuous_update("ce_killfeed_continuous_update", "0", FCVAR_NONE, "Continually updates the killfeed background/icons based on the local player index.")
 {

--- a/CastingEssentials/Modules/Killfeed.h
+++ b/CastingEssentials/Modules/Killfeed.h
@@ -9,6 +9,7 @@ class Killfeed final : public Module<Killfeed>
 {
 public:
 	Killfeed();
+	static constexpr __forceinline const char* GetModuleName() { return "Killfeed Fixes"; }
 
 private:
 	ConVar ce_killfeed_continuous_update;

--- a/CastingEssentials/Modules/Killstreaks.cpp
+++ b/CastingEssentials/Modules/Killstreaks.cpp
@@ -30,6 +30,8 @@
 
 #include "Controls/StubPanel.h"
 
+MODULE_REGISTER(Killstreaks);
+
 std::array<EntityOffset<int>, 4> Killstreaks::s_PlayerStreaks;
 EntityOffset<bool> Killstreaks::s_MedigunHealing;
 EntityOffset<EHANDLE> Killstreaks::s_MedigunHealingTarget;

--- a/CastingEssentials/Modules/Killstreaks.h
+++ b/CastingEssentials/Modules/Killstreaks.h
@@ -18,6 +18,7 @@ public:
 	Killstreaks();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Killstreaks"; }
 
 protected:
 	void OnTick(bool inGame) override;

--- a/CastingEssentials/Modules/LoadoutIcons.cpp
+++ b/CastingEssentials/Modules/LoadoutIcons.cpp
@@ -14,6 +14,8 @@
 #include "vgui_controls/ImagePanel.h"
 #include <vprof.h>
 
+MODULE_REGISTER(LoadoutIcons);
+
 LoadoutIcons::LoadoutIcons() :
 	ce_loadout_enabled("ce_loadout_enabled", "0", FCVAR_NONE, "Enable weapon icons inside player panels in the specgui."),
 	ce_loadout_filter_active_red("ce_loadout_filter_active_red", "255 255 255 255", FCVAR_NONE, "drawcolor_override for red team's active loadout items."),

--- a/CastingEssentials/Modules/LoadoutIcons.h
+++ b/CastingEssentials/Modules/LoadoutIcons.h
@@ -20,6 +20,7 @@ public:
 	LoadoutIcons();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Loadout Icons"; }
 
 protected:
 	void OnTick(bool ingame) override;

--- a/CastingEssentials/Modules/LocalPlayer.cpp
+++ b/CastingEssentials/Modules/LocalPlayer.cpp
@@ -16,6 +16,8 @@
 
 #include <functional>
 
+MODULE_REGISTER(LocalPlayer);
+
 LocalPlayer::LocalPlayer() :
 	ce_localplayer_enabled("ce_localplayer_enabled", "0", FCVAR_NONE, "enable local player override",
 		[](IConVar *var, const char*, float) { GetModule()->ToggleEnabled(static_cast<ConVar*>(var)); }),

--- a/CastingEssentials/Modules/LocalPlayer.h
+++ b/CastingEssentials/Modules/LocalPlayer.h
@@ -12,6 +12,7 @@ public:
 	LocalPlayer();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Local Player"; }
 
 private:
 	void OnTick(bool inGame) override;

--- a/CastingEssentials/Modules/MapConfigs.cpp
+++ b/CastingEssentials/Modules/MapConfigs.cpp
@@ -3,6 +3,8 @@
 
 #include <cdll_int.h>
 
+MODULE_REGISTER(MapConfigs);
+
 MapConfigs::MapConfigs() :
 	ce_mapconfigs_enabled("ce_mapconfigs_enabled", "0", FCVAR_NONE, "If 1, execs cfg/<mapname>.cfg on mapchange.")
 {

--- a/CastingEssentials/Modules/MapConfigs.h
+++ b/CastingEssentials/Modules/MapConfigs.h
@@ -8,6 +8,7 @@ class MapConfigs final : public Module<MapConfigs>
 {
 public:
 	MapConfigs();
+	static constexpr __forceinline const char* GetModuleName() { return "Map Configs"; }
 
 private:
 	ConVar ce_mapconfigs_enabled;

--- a/CastingEssentials/Modules/MedigunInfo.cpp
+++ b/CastingEssentials/Modules/MedigunInfo.cpp
@@ -32,6 +32,8 @@
 
 #include <memdbgon.h>
 
+MODULE_REGISTER(MedigunInfo);
+
 EntityOffset<bool> MedigunInfo::s_ChargeRelease;
 EntityOffset<TFResistType> MedigunInfo::s_ChargeResistType;
 EntityOffset<float> MedigunInfo::s_ChargeLevel;

--- a/CastingEssentials/Modules/MedigunInfo.h
+++ b/CastingEssentials/Modules/MedigunInfo.h
@@ -21,6 +21,7 @@ public:
 	MedigunInfo();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Medigun Info"; }
 
 protected:
 	void LevelShutdown() override;

--- a/CastingEssentials/Modules/MedigunInfo.h
+++ b/CastingEssentials/Modules/MedigunInfo.h
@@ -4,6 +4,7 @@
 #include "PluginBase/Modules.h"
 
 #include <convar.h>
+#include <map>
 
 enum class TFMedigun;
 enum class TFResistType;

--- a/CastingEssentials/Modules/PlayerAliases.cpp
+++ b/CastingEssentials/Modules/PlayerAliases.cpp
@@ -7,6 +7,8 @@
 #include <toolframework/ienginetool.h>
 #include <vprof.h>
 
+MODULE_REGISTER(PlayerAliases);
+
 PlayerAliases::PlayerAliases() :
 	ce_playeraliases_enabled("ce_playeraliases_enabled", "0", FCVAR_NONE, "Enables player aliases.",
 		[](IConVar* var, const char*, float) { GetModule()->ToggleEnabled(static_cast<ConVar*>(var)); }),

--- a/CastingEssentials/Modules/PlayerAliases.h
+++ b/CastingEssentials/Modules/PlayerAliases.h
@@ -13,6 +13,7 @@ public:
 	virtual ~PlayerAliases() = default;
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Player Aliases"; }
 
 private:
 	bool GetPlayerInfoOverride(int ent_num, player_info_s* pInfo);

--- a/CastingEssentials/Modules/ProjectileOutlines.cpp
+++ b/CastingEssentials/Modules/ProjectileOutlines.cpp
@@ -10,6 +10,8 @@
 // smh windows
 #undef IGNORE
 
+MODULE_REGISTER(ProjectileOutlines);
+
 EntityOffset<bool> ProjectileOutlines::s_GlowDisabledOffset;
 EntityOffset<int> ProjectileOutlines::s_GlowModeOffset;
 EntityOffset<EHANDLE> ProjectileOutlines::s_GlowTargetOffset;

--- a/CastingEssentials/Modules/ProjectileOutlines.h
+++ b/CastingEssentials/Modules/ProjectileOutlines.h
@@ -20,6 +20,7 @@ public:
 	ProjectileOutlines();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Projectile Outlines"; }
 
 private:
 	ConVar ce_projectileoutlines_rockets;

--- a/CastingEssentials/Modules/SniperLOS.cpp
+++ b/CastingEssentials/Modules/SniperLOS.cpp
@@ -12,6 +12,8 @@
 #include <tier2/beamsegdraw.h>
 #include <toolframework/ienginetool.h>
 
+MODULE_REGISTER(SniperLOS);
+
 EntityTypeChecker SniperLOS::s_SniperRifleType;
 
 SniperLOS::SniperLOS() :

--- a/CastingEssentials/Modules/SniperLOS.h
+++ b/CastingEssentials/Modules/SniperLOS.h
@@ -14,6 +14,7 @@ public:
 	SniperLOS();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Sniper LOS Beams"; }
 
 private:
 	static EntityTypeChecker s_SniperRifleType;

--- a/CastingEssentials/Modules/SteamTools.cpp
+++ b/CastingEssentials/Modules/SteamTools.cpp
@@ -5,6 +5,8 @@
 #include <steam/steam_api.h>
 #include <toolframework/ienginetool.h>
 
+MODULE_REGISTER(SteamTools);
+
 SteamTools::SteamTools() :
 	ce_steamtools_rp_legacy("ce_steamtools_rp_legacy", "", FCVAR_NONE, "The rich presence status displayed in the \"View Game Info\" dialog.",
 		[](IConVar*, const char*, float) { GetModule()->UpdateRichPresence(); }),

--- a/CastingEssentials/Modules/SteamTools.h
+++ b/CastingEssentials/Modules/SteamTools.h
@@ -10,6 +10,7 @@ public:
 	SteamTools();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Steam Tools"; }
 
 protected:
 	void OnTick(bool inGame) override;

--- a/CastingEssentials/Modules/TeamNames.cpp
+++ b/CastingEssentials/Modules/TeamNames.cpp
@@ -2,6 +2,8 @@
 
 #include <vprof.h>
 
+MODULE_REGISTER(TeamNames);
+
 // Hi we're TOTALLY not hijacking a friend class that's eventually only declared in a cpp file
 class CCvar
 {

--- a/CastingEssentials/Modules/TeamNames.h
+++ b/CastingEssentials/Modules/TeamNames.h
@@ -7,6 +7,7 @@ class TeamNames final : public Module<TeamNames>
 {
 public:
 	TeamNames();
+	static constexpr __forceinline const char* GetModuleName() { return "Team Names"; }
 
 private:
 

--- a/CastingEssentials/Modules/TextureTools.cpp
+++ b/CastingEssentials/Modules/TextureTools.cpp
@@ -5,6 +5,8 @@
 #include <client/baseclientrendertargets.h>
 #include <vtf/vtf.h>
 
+MODULE_REGISTER(TextureTools);
+
 TextureTools::TextureTools() :
 	ce_texturetools_full_res_rts("ce_texturetools_full_res_rts", "0", FCVAR_NONE,
 		"Create the refraction and water reflection textures at framebuffer resolution (if possible). Must be set before the first map load. Changing after that requires a game restart.",

--- a/CastingEssentials/Modules/TextureTools.h
+++ b/CastingEssentials/Modules/TextureTools.h
@@ -13,6 +13,7 @@ public:
 	TextureTools();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Texture Tools"; }
 
 private:
 	Hook<HookFunc::CBaseClientRenderTargets_InitClientRenderTargets> m_CreateRenderTargetsHook;

--- a/CastingEssentials/Modules/ViewAngles.cpp
+++ b/CastingEssentials/Modules/ViewAngles.cpp
@@ -6,6 +6,8 @@
 #include <edict.h>
 #include <icliententity.h>
 
+MODULE_REGISTER(ViewAngles);
+
 EntityOffset<float> ViewAngles::s_EyeAngles0Offset;
 EntityOffset<float> ViewAngles::s_EyeAngles1Offset;
 EntityOffset<float> ViewAngles::s_KartBoostOffset;

--- a/CastingEssentials/Modules/ViewAngles.h
+++ b/CastingEssentials/Modules/ViewAngles.h
@@ -6,6 +6,7 @@
 #include <dt_recv.h>
 
 #include <optional>
+#include <map>
 
 class ConCommand;
 class IConVar;

--- a/CastingEssentials/Modules/ViewAngles.h
+++ b/CastingEssentials/Modules/ViewAngles.h
@@ -16,6 +16,7 @@ public:
 	ViewAngles();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "High-Precision View Angles"; }
 
 protected:
 	void OnTick(bool inGame) override;

--- a/CastingEssentials/Modules/WeaponTools.cpp
+++ b/CastingEssentials/Modules/WeaponTools.cpp
@@ -13,6 +13,8 @@
 
 #include <Windows.h>
 
+MODULE_REGISTER(WeaponTools);
+
 WeaponTools::WeaponTools() :
 	ce_weapon_inspect_debug("ce_weapon_inspect_debug", "0", FCVAR_NONE),
 	ce_weapon_inspect_block("ce_weapon_inspect_block", "0", FCVAR_NONE, "Don't play weapon inspect animations when triggered by players.",

--- a/CastingEssentials/Modules/WeaponTools.h
+++ b/CastingEssentials/Modules/WeaponTools.h
@@ -29,6 +29,7 @@ public:
 	WeaponTools();
 
 	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "Weapon Tools"; }
 
 protected:
 	void OnTick(bool inGame) override;

--- a/CastingEssentials/PluginBase/CastingPlugin.cpp
+++ b/CastingEssentials/PluginBase/CastingPlugin.cpp
@@ -73,38 +73,38 @@ bool CastingPlugin::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn g
 
 	Modules().Init();
 
-	Modules().RegisterAndLoadModule<HUDHacking>("Evil HUD Modifications");
+	Modules().RegisterAndLoadModule<HUDHacking>();
 
 	// CameraTools and CameraSmooths depend on CameraState
-	Modules().RegisterAndLoadModule<CameraState>("Camera State");
-	Modules().RegisterAndLoadModule<CameraTools>("Camera Tools");
-	Modules().RegisterAndLoadModule<CameraSmooths>("Camera Smooths");
+	Modules().RegisterAndLoadModule<CameraState>();
+	Modules().RegisterAndLoadModule<CameraTools>();
+	Modules().RegisterAndLoadModule<CameraSmooths>();
 
-	Modules().RegisterAndLoadModule<AntiFreeze>("HUD Antifreeze");
-	Modules().RegisterAndLoadModule<AutoCameras>("AutoCameras");
-	Modules().RegisterAndLoadModule<CameraAutoSwitch>("Camera Auto-Switch");
-	Modules().RegisterAndLoadModule<ConsoleTools>("Console Tools");
-	Modules().RegisterAndLoadModule<FOVOverride>("FOV Override");
-	Modules().RegisterAndLoadModule<FreezeInfo>("Freeze Info");
-	Modules().RegisterAndLoadModule<Graphics>("Graphics Enhancements");
-	Modules().RegisterAndLoadModule<HitEvents>("Player Hit Events");
-	Modules().RegisterAndLoadModule<IngameTeamScores>("Ingame Team Scores");
-	Modules().RegisterAndLoadModule<ItemSchema>("Item Schema");
-	Modules().RegisterAndLoadModule<Killfeed>("Killfeed Fixes");
-	Modules().RegisterAndLoadModule<Killstreaks>("Killstreaks");
-	Modules().RegisterAndLoadModule<LoadoutIcons>("Loadout Icons");
-	Modules().RegisterAndLoadModule<LocalPlayer>("Local Player");
-	Modules().RegisterAndLoadModule<MapConfigs>("Map Configs");
-	Modules().RegisterAndLoadModule<MedigunInfo>("Medigun Info");
-	Modules().RegisterAndLoadModule<PlayerAliases>("Player Aliases");
-	Modules().RegisterAndLoadModule<ProjectileOutlines>("Projectile Outlines");
-	Modules().RegisterAndLoadModule<SniperLOS>("Sniper LOS Beams");
-	Modules().RegisterAndLoadModule<SteamTools>("Steam Tools");
-	Modules().RegisterAndLoadModule<TeamNames>("Team Names");
-	Modules().RegisterAndLoadModule<TextureTools>("Texture Tools");
-	Modules().RegisterAndLoadModule<ClientTools>("Client Tools");
-	Modules().RegisterAndLoadModule<ViewAngles>("High-Precision View Angles");
-	Modules().RegisterAndLoadModule<WeaponTools>("Weapon Tools");
+	Modules().RegisterAndLoadModule<AntiFreeze>();
+	Modules().RegisterAndLoadModule<AutoCameras>();
+	Modules().RegisterAndLoadModule<CameraAutoSwitch>();
+	Modules().RegisterAndLoadModule<ConsoleTools>();
+	Modules().RegisterAndLoadModule<FOVOverride>();
+	Modules().RegisterAndLoadModule<FreezeInfo>();
+	Modules().RegisterAndLoadModule<Graphics>();
+	Modules().RegisterAndLoadModule<HitEvents>();
+	Modules().RegisterAndLoadModule<IngameTeamScores>();
+	Modules().RegisterAndLoadModule<ItemSchema>();
+	Modules().RegisterAndLoadModule<Killfeed>();
+	Modules().RegisterAndLoadModule<Killstreaks>();
+	Modules().RegisterAndLoadModule<LoadoutIcons>();
+	Modules().RegisterAndLoadModule<LocalPlayer>();
+	Modules().RegisterAndLoadModule<MapConfigs>();
+	Modules().RegisterAndLoadModule<MedigunInfo>();
+	Modules().RegisterAndLoadModule<PlayerAliases>();
+	Modules().RegisterAndLoadModule<ProjectileOutlines>();
+	Modules().RegisterAndLoadModule<SniperLOS>();
+	Modules().RegisterAndLoadModule<SteamTools>();
+	Modules().RegisterAndLoadModule<TeamNames>();
+	Modules().RegisterAndLoadModule<TextureTools>();
+	Modules().RegisterAndLoadModule<ClientTools>();
+	Modules().RegisterAndLoadModule<ViewAngles>();
+	Modules().RegisterAndLoadModule<WeaponTools>();
 
 	ConVar_Register();
 

--- a/CastingEssentials/PluginBase/CastingPlugin.cpp
+++ b/CastingEssentials/PluginBase/CastingPlugin.cpp
@@ -72,45 +72,13 @@ bool CastingPlugin::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn g
 	Player::Load();
 
 	Modules().Init();
-
-	Modules().RegisterAndLoadModule<HUDHacking>();
-
-	// CameraTools and CameraSmooths depend on CameraState
-	Modules().RegisterAndLoadModule<CameraState>();
-	Modules().RegisterAndLoadModule<CameraTools>();
-	Modules().RegisterAndLoadModule<CameraSmooths>();
-
-	Modules().RegisterAndLoadModule<AntiFreeze>();
-	Modules().RegisterAndLoadModule<AutoCameras>();
-	Modules().RegisterAndLoadModule<CameraAutoSwitch>();
-	Modules().RegisterAndLoadModule<ConsoleTools>();
-	Modules().RegisterAndLoadModule<FOVOverride>();
-	Modules().RegisterAndLoadModule<FreezeInfo>();
-	Modules().RegisterAndLoadModule<Graphics>();
-	Modules().RegisterAndLoadModule<HitEvents>();
-	Modules().RegisterAndLoadModule<IngameTeamScores>();
-	Modules().RegisterAndLoadModule<ItemSchema>();
-	Modules().RegisterAndLoadModule<Killfeed>();
-	Modules().RegisterAndLoadModule<Killstreaks>();
-	Modules().RegisterAndLoadModule<LoadoutIcons>();
-	Modules().RegisterAndLoadModule<LocalPlayer>();
-	Modules().RegisterAndLoadModule<MapConfigs>();
-	Modules().RegisterAndLoadModule<MedigunInfo>();
-	Modules().RegisterAndLoadModule<PlayerAliases>();
-	Modules().RegisterAndLoadModule<ProjectileOutlines>();
-	Modules().RegisterAndLoadModule<SniperLOS>();
-	Modules().RegisterAndLoadModule<SteamTools>();
-	Modules().RegisterAndLoadModule<TeamNames>();
-	Modules().RegisterAndLoadModule<TextureTools>();
-	Modules().RegisterAndLoadModule<ClientTools>();
-	Modules().RegisterAndLoadModule<ViewAngles>();
-	Modules().RegisterAndLoadModule<WeaponTools>();
+	Modules().LoadAll();
 
 	ConVar_Register();
 
 	const auto endTime = std::chrono::high_resolution_clock::now();
 	const auto delta = std::chrono::duration<float>(endTime - startTime);
-	PluginMsg("Finished loading in %1.2f seconds.\n", delta.count());
+	PluginMsg("Finished loading %d modules in %1.2f seconds.\n", Modules().size(), delta.count());
 
 	return true;
 }

--- a/CastingEssentials/PluginBase/Exceptions.h
+++ b/CastingEssentials/PluginBase/Exceptions.h
@@ -29,6 +29,35 @@ private:
 	const char *moduleName;
 };
 
+class module_load_failed : public std::exception
+{
+public:
+	module_load_failed(const char *name) noexcept : moduleName(name) {}
+	virtual const char *what() const noexcept { return moduleName.c_str(); }
+private:
+	std::string moduleName;
+};
+
+class module_circular_dependency : public std::exception
+{
+public:
+	module_circular_dependency(const char *name) noexcept : moduleName(name) {}
+	virtual const char *what() const noexcept { return moduleName.c_str(); }
+private:
+	std::string moduleName;
+	std::string message;
+};
+
+class module_dependency_failed : public std::exception
+{
+public:
+	module_dependency_failed(const char *name) noexcept : moduleName(name) {}
+	virtual const char *what() const noexcept { return moduleName.c_str(); }
+private:
+	std::string moduleName;
+	std::string message;
+};
+
 class bad_pointer : public std::exception
 {
 public:

--- a/CastingEssentials/PluginBase/Modules.cpp
+++ b/CastingEssentials/PluginBase/Modules.cpp
@@ -9,6 +9,7 @@ static ModuleManager s_ModuleManager;
 ModuleManager& Modules() { return s_ModuleManager; }
 
 bool IBaseModule::s_InGame;
+ModuleDesc* g_ModuleList = nullptr;
 
 class ModuleManager::Panel final : public vgui::StubPanel
 {
@@ -31,7 +32,7 @@ void ModuleManager::UnloadAllModules()
 {
 	for (auto iterator = modules.rbegin(); iterator != modules.rend(); iterator++)
 	{
-		auto mod = iterator->m_Module->ZeroSingleton(); // Grab the singleton instance
+		auto mod = iterator->m_Module->ReplaceSingleton(nullptr); // Grab the singleton instance
 		const std::string moduleName(mod->GetModuleName());
 		mod = nullptr;
 		PluginColorMsg(Color(0, 255, 0, 255), "Module %s unloaded!\n", moduleName.c_str());
@@ -39,6 +40,59 @@ void ModuleManager::UnloadAllModules()
 
 	modules.clear();
 	m_Panel.reset();
+}
+
+void ModuleManager::LoadAll()
+{
+	auto md = g_ModuleList;
+	while (md) {
+		try {
+			Load(*md);
+		}
+		catch (const std::exception&) { }
+		md = md->next;
+	}
+}
+
+void ModuleManager::Load(ModuleDesc& desc)
+{
+	switch (desc.state) {
+	case ModuleState::MODULE_FAILED:
+		throw module_load_failed(desc.name.c_str());
+	case ModuleState::MODULE_LOADING:
+		throw module_circular_dependency(desc.name.c_str());
+	case ModuleState::MODULE_LOADED:
+		return;
+	}
+
+	desc.state = ModuleState::MODULE_LOADING;
+	try
+	{
+		auto mod = desc.factory();
+		Assert(mod);
+		modules.push_back({ mod.get() });
+		mod->ReplaceSingleton(std::move(mod));
+		desc.state = ModuleState::MODULE_LOADED;
+		PluginColorMsg(Color(0, 255, 0, 255), "Module %s loaded successfully!\n", desc.name.c_str());
+	}
+	catch (const module_circular_dependency& e)
+	{
+		desc.state = ModuleState::MODULE_FAILED;
+		PluginColorMsg(Color(255, 0, 0, 255), "Module %s failed to load because of circular dependency on module %s!\n", desc.name.c_str(), e.what());
+		throw module_load_failed(desc.name.c_str());
+	}
+	catch (const module_dependency_failed& e)
+	{
+		desc.state = ModuleState::MODULE_FAILED;
+		PluginColorMsg(Color(255, 0, 0, 255), "Module %s failed to load because dependency %s did not load!\n", desc.name.c_str(), e.what());
+		throw module_load_failed(desc.name.c_str());
+	}
+	catch (const std::exception&)
+	{
+		desc.state = ModuleState::MODULE_FAILED;
+		PluginColorMsg(Color(255, 0, 0, 255), "Module %s failed to load!\n", desc.name.c_str());
+		throw module_load_failed(desc.name.c_str());
+	}
 }
 
 void ModuleManager::Panel::LevelInitAllModules()

--- a/CastingEssentials/PluginBase/Modules.cpp
+++ b/CastingEssentials/PluginBase/Modules.cpp
@@ -31,9 +31,9 @@ void ModuleManager::UnloadAllModules()
 {
 	for (auto iterator = modules.rbegin(); iterator != modules.rend(); iterator++)
 	{
-		const std::string moduleName(iterator->second.m_Module->GetModuleName());
-		iterator->second.m_Module.reset();				// Delete the module
-		*iterator->second.m_Pointer = nullptr;			// Zero out the static pointer to self
+		auto mod = iterator->m_Module->ZeroSingleton(); // Grab the singleton instance
+		const std::string moduleName(mod->GetModuleName());
+		mod = nullptr;
 		PluginColorMsg(Color(0, 255, 0, 255), "Module %s unloaded!\n", moduleName.c_str());
 	}
 
@@ -45,15 +45,15 @@ void ModuleManager::Panel::LevelInitAllModules()
 {
 	IBaseModule::s_InGame = true;
 
-	for (const auto& pair : Modules().modules)
-		pair.second.m_Module->LevelInit();
+	for (const auto& data : Modules().modules)
+		data.m_Module->LevelInit();
 }
 void ModuleManager::Panel::LevelShutdownAllModules()
 {
 	IBaseModule::s_InGame = false;
 
-	for (const auto& pair : Modules().modules)
-		pair.second.m_Module->LevelShutdown();
+	for (const auto& data : Modules().modules)
+		data.m_Module->LevelShutdown();
 }
 
 void ModuleManager::Panel::OnTick()
@@ -87,6 +87,6 @@ void ModuleManager::Panel::OnTick()
 
 void ModuleManager::TickAllModules(bool inGame)
 {
-	for (const auto& pair : modules)
-		pair.second.m_Module->OnTick(inGame);
+	for (const auto& data : modules)
+		data.m_Module->OnTick(inGame);
 }

--- a/CastingEssentials/PluginBase/Modules.cpp
+++ b/CastingEssentials/PluginBase/Modules.cpp
@@ -31,9 +31,10 @@ void ModuleManager::UnloadAllModules()
 {
 	for (auto iterator = modules.rbegin(); iterator != modules.rend(); iterator++)
 	{
+		const std::string moduleName(iterator->second.m_Module->GetModuleName());
 		iterator->second.m_Module.reset();				// Delete the module
 		*iterator->second.m_Pointer = nullptr;			// Zero out the static pointer to self
-		PluginColorMsg(Color(0, 255, 0, 255), "Module %s unloaded!\n", iterator->second.m_Name.c_str());
+		PluginColorMsg(Color(0, 255, 0, 255), "Module %s unloaded!\n", moduleName.c_str());
 	}
 
 	modules.clear();

--- a/CastingEssentials/Properties/Shared.props
+++ b/CastingEssentials/Properties/Shared.props
@@ -15,7 +15,7 @@
     </Link>
     <ClCompile>
       <TreatSpecificWarningsAsErrors>4715;4717;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
-      <PreprocessorDefinitions>SUPPRESS_INVALID_PARAMETER_NO_INFO;VERSION_SAFE_STEAM_API_INTERFACES;CLIENT_DLL;WIN32;RAD_TELEMETRY_DISABLED;TF2_SDK;TF_CLIENT_DLL;NO_PCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SUPPRESS_INVALID_PARAMETER_NO_INFO;VERSION_SAFE_STEAM_API_INTERFACES;CLIENT_DLL;WIN32;RAD_TELEMETRY_DISABLED;TF2_SDK;TF_CLIENT_DLL;NO_PCH;_X86_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedIncludeFiles>$(ProjectDir)PluginBase\Common.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <DisableSpecificWarnings>4594;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
These commits refactor the module system to do away with almost all dynamic dispatch and introduce a module registration system such that modules no longer have to be loaded manually from `CastingPlugin.cpp`. This makes it somewhat easier to develop new modules while keeping up with upstream.

A simple dependency mechanism is introduced, such that a module may declare a dependency on another. This works recursively, and checks for circular dependencies. A circular dependency is currently treated as an error, but it could be beneficial to allow them. I'm unsure on this.