### PR TITLE
Improve error handling in TickAllModules

### DIFF
--- a/CastingEssentials/PluginBase/Modules.cpp
+++ b/CastingEssentials/PluginBase/Modules.cpp
@@ -141,6 +141,15 @@ void ModuleManager::Panel::OnTick()
 
 void ModuleManager::TickAllModules(bool inGame)
 {
-	for (const auto& data : modules)
-		data.m_Module->OnTick(inGame);
+	auto ite = modules.begin();
+	while (ite != modules.end()) {
+		try {
+			ite->m_Module->OnTick(inGame);
+			++ite;
+		}
+		catch (std::exception e) {
+			PluginColorMsg(Color(255, 0, 0, 255), "Module %s tick failed, disabling: %s\n", ite->m_Module->GetModuleName(), e.what());
+			ite = modules.erase(ite);
+		}
+	}
 }


### PR DESCRIPTION
If a module throws an exception during OnTick the client will crash.
This could happen if module has not been updated and CheckDependencies
didn't capture all dependencies.

Here we refactor the tick loop so OnTick is wrapped in a try...catch
block. If a module throws an exception, it will be removed from the
module list.

I checked the assembly of this, and benchmarked it, to ensure that
there's no performance loss by doing this compared to the existing
solution. I've seen no performance drops in testing, and the assembly
looks effficient(more instructions, but most will be predicted).