### PR TITLE
Refactor hitevents and support heal events

### DIFF
--- a/CastingEssentials/Modules/HitEvents.h
+++ b/CastingEssentials/Modules/HitEvents.h
@@ -16,7 +16,7 @@ class C_TFPlayer;
 class IHandleEntity;
 using trace_t = class CGameTrace;
 
-class HitEvents final : public Module<HitEvents>, IGameEventListener2
+class HitEvents final : public Module<HitEvents>
 {
 public:
 	HitEvents();
@@ -25,8 +25,6 @@ public:
 	static constexpr __forceinline const char* GetModuleName() { return "Player Hit Events"; }
 
 protected:
-	void FireGameEvent(IGameEvent* event) override;
-
 	void LevelInit() override;
 	void LevelShutdown() override;
 
@@ -35,14 +33,14 @@ private:
 
 	void UpdateEnabledState();
 
-	void DisplayDamageFeedbackOverride(CDamageAccountPanel* pThis, C_TFPlayer* pAttacker, C_BaseCombatCharacter* pVictim, int iDamageAmount, int iHealth, bool unknown);
+	void FireGameEventOverride(CDamageAccountPanel* pThis, IGameEvent* event);
 
 	bool m_OverrideUTILTraceline;
 	void UTILTracelineOverride(const Vector& vecAbsStart, const Vector& vecAbsEnd, unsigned int mask, const IHandleEntity* ignore, int collisionGroup, trace_t* ptr);
 
 	bool DamageAccountPanelShouldDrawOverride(CDamageAccountPanel* pThis);
 
-	Hook<HookFunc::CDamageAccountPanel_DisplayDamageFeedback> m_DisplayDamageFeedbackHook;
+	Hook<HookFunc::CDamageAccountPanel_FireGameEvent> m_FireGameEventHook;
 	Hook<HookFunc::Global_UTIL_TraceLine> m_UTILTracelineHook;
 	Hook<HookFunc::CDamageAccountPanel_ShouldDraw> m_DamageAccountPanelShouldDrawHook;
 
@@ -50,7 +48,4 @@ private:
 
 	ConVar ce_hitevents_enabled;
 	ConVar ce_hitevents_dmgnumbers_los;
-	ConVar ce_hitevents_debug;
-
-	IGameEvent* TriggerPlayerHurt(int playerEntIndex, int damage);
 };

--- a/CastingEssentials/PluginBase/HookDefinitions.h
+++ b/CastingEssentials/PluginBase/HookDefinitions.h
@@ -103,7 +103,7 @@ enum class HookFunc
 	CAccountPanel_Paint,
 	CAutoGameSystemPerFrame_CAutoGameSystemPerFrame,
 	CBaseClientRenderTargets_InitClientRenderTargets,
-	CDamageAccountPanel_DisplayDamageFeedback,
+	CDamageAccountPanel_FireGameEvent,
 	CDamageAccountPanel_ShouldDraw,
 
 	CParticleProperty_DebugPrintEffects,
@@ -403,10 +403,10 @@ protected:
 		typedef void(__thiscall* Raw)(CBaseClientRenderTargets* pThis, IMaterialSystem* pMaterialSystem, IMaterialSystemHardwareConfig* config, int iWaterTextureSize, int iCameraTextureSize);
 		typedef GlobalClassHook<HookFunc::CBaseClientRenderTargets_InitClientRenderTargets, false, CBaseClientRenderTargets, void, IMaterialSystem*, IMaterialSystemHardwareConfig*, int, int> Hook;
 	};
-	template<> struct HookFuncType<HookFunc::CDamageAccountPanel_DisplayDamageFeedback>
+	template<> struct HookFuncType<HookFunc::CDamageAccountPanel_FireGameEvent>
 	{
-		typedef void(__thiscall *Raw)(CDamageAccountPanel* pThis, C_TFPlayer* pAttacker, C_BaseCombatCharacter* pVictim, int iDamageAmount, int iHealth, bool unknown);
-		typedef GlobalClassHook<HookFunc::CDamageAccountPanel_DisplayDamageFeedback, false, CDamageAccountPanel, void, C_TFPlayer*, C_BaseCombatCharacter*, int, int, bool> Hook;
+		typedef void(__thiscall *Raw)(CDamageAccountPanel* pThis, IGameEvent*);
+		typedef GlobalClassHook<HookFunc::CDamageAccountPanel_FireGameEvent, false, CDamageAccountPanel, void, IGameEvent*> Hook;
 	};
 	template<> struct HookFuncType<HookFunc::CDamageAccountPanel_ShouldDraw>
 	{

--- a/CastingEssentials/PluginBase/HookManager.cpp
+++ b/CastingEssentials/PluginBase/HookManager.cpp
@@ -172,7 +172,7 @@ void HookManager::InitRawFunctionsList()
 	FindFunc<HookFunc::CAccountPanel_OnAccountValueChanged>("\x55\x8B\xEC\x51\x53\x8B\x5D\x0C\x56\x8B\xF1\x53", "xxxxxxxxxxxx");
 	FindFunc<HookFunc::CAccountPanel_Paint>("\x55\x8B\xEC\x83\xEC\x74\x56\x8B\xC1", "xxxxxxxxx");
 	FindFunc<HookFunc::CBaseClientRenderTargets_InitClientRenderTargets>("\x55\x8B\xEC\x51\x53\x8B\x5D\x08\x56\x57\x6A\x01", "xxxxxxxxxxxx");
-	FindFunc<HookFunc::CDamageAccountPanel_DisplayDamageFeedback>("\x55\x8B\xEC\x81\xEC????\x83\x7D\x10\x00\x53\x8B\xD9\x0F\x8E", "xxxxx????xxxxxxxxx");
+	FindFunc<HookFunc::CDamageAccountPanel_FireGameEvent>("\x55\x8B\xEC\x83\xEC\x1C\x53\x8B\x5D\x08\x56\x89\x4D\xFC\x8B\xCB\x57\x8B\x03\xFF\x50\x04\x3D", "xxxxxxxxxxxxxxxxxxxxxxx");
 	FindFunc<HookFunc::CDamageAccountPanel_ShouldDraw>("\x56\x8B\xF1\xE8????\x8B\xC8\x85\xC9\x74\x0E", "xxxx????xxxxxx");
 
 	FindFunc<HookFunc::CParticleProperty_DebugPrintEffects>("\x55\x8B\xEC\x51\x8B\xC1\x53\x56\x33\xF6\x89\x45\xFC\x8B\x58\x14", "xxxxxxxxxxxxxxxx");
@@ -284,7 +284,7 @@ HookManager::HookManager()
 	InitGlobalHook<HookFunc::CAccountPanel_OnAccountValueChanged>();
 	InitGlobalHook<HookFunc::CAccountPanel_Paint>();
 	InitGlobalHook<HookFunc::CBaseClientRenderTargets_InitClientRenderTargets>();
-	InitGlobalHook<HookFunc::CDamageAccountPanel_DisplayDamageFeedback>();
+	InitGlobalHook<HookFunc::CDamageAccountPanel_FireGameEvent>();
 	InitGlobalHook<HookFunc::CDamageAccountPanel_ShouldDraw>();
 
 	InitGlobalHook<HookFunc::CViewRender_PerformScreenSpaceEffects>();


### PR DESCRIPTION
Mainly this is a refactoring job, with the added bonus of getting
healevents in the damage account panel as well. Heal and hurt events are
very similar, so the code paths are shared.

The former hook was on `CDamageAccountPanel::DisplayDamageFeedback` but
since it was needed to hook `CDamageAccountPanel::FireGameEvent` anyway
to support heal events(a `localPlayer->m_lifeState = LIFE_ALIVE` check)
the module no longer has its own `FireGameEvent` anymore, instead moving
the required functionality directly to the hook.