### PR TITLE
Fix disappearing particle effects e.g. heal beams

### DIFF
--- a/CastingEssentials/Modules/Graphics.h
+++ b/CastingEssentials/Modules/Graphics.h
@@ -41,6 +41,7 @@ private:
 	ConVar ce_graphics_glow_silhouettes;
 	ConVar ce_graphics_improved_glows;
 	ConVar ce_graphics_fix_invisible_players;
+	ConVar ce_graphics_fix_viewmodel_particles;
 
 	ConVar ce_graphics_fxaa;
 	ConVar ce_graphics_fxaa_debug;
@@ -99,6 +100,13 @@ private:
 
 	Hook<HookFunc::IStudioRender_ForcedMaterialOverride> m_ForcedMaterialOverrideHook;
 	void ForcedMaterialOverrideOverride(IMaterial* material, OverrideType_t overrideType);
+
+	Hook<HookFunc::C_BasePlayer_ShouldDrawLocalPlayer> m_ShouldDrawLocalPlayerHook;
+	Hook<HookFunc::C_TFWeaponBase_PostDataUpdate> m_PostDataUpdateHook;
+	C_BaseEntity* m_LocalOwner{ nullptr };
+	void ToggleFixViewmodel(const ConVar* var);
+	void PostDataUpdateOverride(IClientNetworkable* pThis, int updateType);
+	bool ShouldDrawLocalPlayerOverride(C_BasePlayer* pThis);
 
 	void DrawGlowAlways(int nSplitScreenSlot, CMatRenderContextPtr& pRenderContext) const;
 	void DrawGlowOccluded(int nSplitScreenSlot, CMatRenderContextPtr& pRenderContext) const;

--- a/CastingEssentials/PluginBase/HookDefinitions.h
+++ b/CastingEssentials/PluginBase/HookDefinitions.h
@@ -11,6 +11,8 @@ class C_BaseCombatCharacter;
 class C_BasePlayer;
 class C_HLTVCamera;
 class C_TFViewModel;
+class C_TFWeaponBase;
+class C_BaseCombatWeapon;
 class CAccountPanel;
 class CAutoGameSystemPerFrame;
 class CBaseClientRenderTargets;
@@ -98,6 +100,8 @@ enum class HookFunc
 	C_TFPlayer_GetEntityForLoadoutSlot,
 
 	C_TFViewModel_CalcViewModelView,
+
+	C_TFWeaponBase_PostDataUpdate,
 
 	CAccountPanel_OnAccountValueChanged,
 	CAccountPanel_Paint,
@@ -349,7 +353,8 @@ protected:
 	};
 	template<> struct HookFuncType<HookFunc::C_BasePlayer_ShouldDrawLocalPlayer>
 	{
-		typedef bool(*Raw)();
+		typedef bool(__thiscall *Raw)(C_BasePlayer* pThis);
+		typedef GlobalClassHook<HookFunc::C_BasePlayer_ShouldDrawLocalPlayer, false, C_BasePlayer, bool> Hook;
 	};
 	template<> struct HookFuncType<HookFunc::C_TFPlayer_DrawModel>
 	{
@@ -364,6 +369,11 @@ protected:
 	{
 		typedef void(__thiscall *Raw)(C_TFViewModel* pThis, C_BasePlayer* player, const Vector& eyePos, const QAngle& eyeAng);
 		typedef GlobalClassHook<HookFunc::C_TFViewModel_CalcViewModelView, false, C_TFViewModel, void, C_BasePlayer*, const Vector&, const QAngle&> Hook;
+	};
+	template<> struct HookFuncType<HookFunc::C_TFWeaponBase_PostDataUpdate>
+	{
+		typedef void(__thiscall *Raw)(IClientNetworkable* pThis, int updateType);
+		typedef GlobalClassHook<HookFunc::C_TFWeaponBase_PostDataUpdate, false, IClientNetworkable, void, int> Hook;
 	};
 	template<> struct HookFuncType<HookFunc::vgui_AnimationController_StartAnimationSequence>
 	{

--- a/CastingEssentials/PluginBase/HookManager.cpp
+++ b/CastingEssentials/PluginBase/HookManager.cpp
@@ -160,7 +160,7 @@ void HookManager::InitRawFunctionsList()
 
 	FindFunc<HookFunc::C_BasePlayer_GetDefaultFOV>("\x57\x8B\xF9\x8B\x07\xFF\x90????\x83\xF8\x04", "xxxxxxx????xxx");
 	FindFunc<HookFunc::C_BasePlayer_GetFOV>("\x55\x8B\xEC\x83\xEC\x10\x56\x8B\xF1\x8B\x0D????\x8B\x01", "xxxxxxxxxxx????xx");
-	FindFunc<HookFunc::C_BasePlayer_ShouldDrawLocalPlayer>("\x8B\x0D????\x85\xC9\x74\x3B\x8B\x01", "xx????xxxxxx");
+	FindFunc<HookFunc::C_BasePlayer_ShouldDrawLocalPlayer>("\x56\x57\x8B\x3D????\x8B\xF1\x3B\xFE\x74\x3F\x85\xFF\x0F\x84\xA5\x00\x00\x00\x8B\x07\x8B\xCF\xFF\x90\xC8\x03\x00\x00\x83\xF8\x04\x0F\x85\x92\x00\x00\x00", "xxxx????xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
 
 	FindFunc<HookFunc::C_HLTVCamera_SetCameraAngle>("\x55\x8B\xEC\x8B\x45\x08\x56\x8B\xF1\x8D\x56\x00\xD9\x00\xD9\x1A\xD9\x40\x00\xD9\x5A\x00\xD9\x40\x00\x52", "xxxxxxxxxxx?xxxxxx?xx?xx?x");
 	FindFunc<HookFunc::C_HLTVCamera_SetMode>("\x55\x8B\xEC\x8B\x45\x08\x53\x56\x8B\xF1\x8B\x5E\x00", "xxxxxxxxxxxx?");
@@ -168,6 +168,8 @@ void HookManager::InitRawFunctionsList()
 
 	FindFunc<HookFunc::C_TFPlayer_DrawModel>("\x55\x8B\xEC\x51\x57\x8B\xF9\x80\x7F\x54\x17", "xxxxxxxxxxx");
 	FindFunc<HookFunc::C_TFPlayer_GetEntityForLoadoutSlot>("\x55\x8B\xEC\x51\x53\x8B\x5D\x08\x57\x8B\xF9\x89\x7D\xFC\x83\xFB\x07", "xxxxxxxxxxxxxxxxx");
+
+	FindFunc<HookFunc::C_TFWeaponBase_PostDataUpdate>("\x55\x8B\xEC\x53\x56\x57\x8B\xF9\x8D\x4F\xF8\xE8\x60\x55\xB9\xFF\x8B\xF0\x85\xF6\x74\x10\x8B\x06\x8B\xCE\x8B\x80\x0C\x02\x00\x00\xFF\xD0\x84\xC0\x75\x02", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
 
 	FindFunc<HookFunc::CAccountPanel_OnAccountValueChanged>("\x55\x8B\xEC\x51\x53\x8B\x5D\x0C\x56\x8B\xF1\x53", "xxxxxxxxxxxx");
 	FindFunc<HookFunc::CAccountPanel_Paint>("\x55\x8B\xEC\x83\xEC\x74\x56\x8B\xC1", "xxxxxxxxx");
@@ -275,7 +277,9 @@ HookManager::HookManager()
 	InitGlobalHook<HookFunc::C_BaseAnimating_DrawModel>();
 	InitGlobalHook<HookFunc::C_BaseAnimating_InternalDrawModel>();
 	InitGlobalHook<HookFunc::C_BasePlayer_GetDefaultFOV>();
+	InitGlobalHook<HookFunc::C_BasePlayer_ShouldDrawLocalPlayer>();
 	InitGlobalHook<HookFunc::C_TFPlayer_DrawModel>();
+	InitGlobalHook<HookFunc::C_TFWeaponBase_PostDataUpdate>();
 
 	InitGlobalHook<HookFunc::C_BaseEntity_Init>();
 


### PR DESCRIPTION
On SourceTV medic beams disappear shortly after the medic starts
healing, and unusual weapon effects have the same problem.

The problem is caused by `C_TFWeaponBase::PostDataUpdate` not correctly
comparing the model index when receiving it from the server. Because
of how weapon models works, special handling is needed when in first
person view because the same backing model is used for world and view
models now.

`C_BasePlayer::ShouldDrawLocalPlayer` is the check that determines which
model we are to use, and because it doesn't handle SourceTV is picks the
wrong one, with model overrides and disappearing particle collections as
a result.

Because `ShouldDrawLocalPlayer` doesn't have the context needed to check
if a given weapon belongs to the currently viewed player, so we can't
simply hook it and override its results. Luckily, it turns out that we
don't need to override it in general, just when it's called from
`PostDataUpdate`. So we just hook both and keep the weapon owner as
state(managed by a variable pusher), and this allows us to check if the
given model belongs to the local player.

The fix is behind the cvar `ce_graphics_fix_viewmodel_particles` which
defaults to `1`.

I decided to put this in the `Graphics` module because it seems like a
graphical fix, so most people will likely look for it here. This does
introduce a soft dependency on `CameraState`, as we use the
`GetLocalObserverMode` and `GetLocalObserverMode` helpers to figure out
the correct states, but should `CameraState` break the fix can simply be
disabled with the `cvar` such that CE continues to function.