### PR TITLE
Fix update projectile colors

### DIFF
--- a/CastingEssentials/Modules/ProjectileOutlines.cpp
+++ b/CastingEssentials/Modules/ProjectileOutlines.cpp
@@ -154,7 +154,7 @@ void ProjectileOutlines::OnTick(bool inGame)
 	}
 }
 
-CHandle<C_BaseEntity> ProjectileOutlines::CreateGlowForEntity(IClientEntity* projectileEntity)
+void ProjectileOutlines::CreateGlowForEntity(IClientEntity* projectileEntity)
 {
 	C_BaseEntity* ent;
 	{
@@ -181,7 +181,7 @@ CHandle<C_BaseEntity> ProjectileOutlines::CreateGlowForEntity(IClientEntity* pro
 
 	ent->PostDataUpdate(DataUpdateType_t::DATA_UPDATE_CREATED);
 	ent->PostDataUpdate(DataUpdateType_t::DATA_UPDATE_DATATABLE_CHANGED);
-	return ent;
+	m_GlowEntities.emplace(projectileEntity->GetRefEHandle().ToInt(), ent);
 }
 
 void ProjectileOutlines::SoldierGlows(IClientEntity* entity)
@@ -195,7 +195,7 @@ void ProjectileOutlines::SoldierGlows(IClientEntity* entity)
 	if (entity->GetClientClass() != s_RocketType)
 		return;
 
-	m_GlowEntities.insert(std::make_pair<int, EHANDLE>(entity->GetRefEHandle().ToInt(), CreateGlowForEntity(entity)));
+	CreateGlowForEntity(entity);
 }
 
 void ProjectileOutlines::DemoGlows(IClientEntity* entity)
@@ -213,9 +213,9 @@ void ProjectileOutlines::DemoGlows(IClientEntity* entity)
 		return;
 
 	if (pills && type == TFGrenadePipebombType::Pill)
-		m_GlowEntities.insert(std::make_pair<int, EHANDLE>(entity->GetRefEHandle().ToInt(), CreateGlowForEntity(entity)));
+		CreateGlowForEntity(entity);
 	else if (stickies && (type == TFGrenadePipebombType::Sticky || type == TFGrenadePipebombType::StickyJumper))
-		m_GlowEntities.insert(std::make_pair<int, EHANDLE>(entity->GetRefEHandle().ToInt(), CreateGlowForEntity(entity)));
+		CreateGlowForEntity(entity);
 }
 
 bool ProjectileOutlines::InitDetour(C_BaseEntity* pThis, int entnum, int iSerialNum)

--- a/CastingEssentials/Modules/ProjectileOutlines.h
+++ b/CastingEssentials/Modules/ProjectileOutlines.h
@@ -40,7 +40,7 @@ private:
 	void SoldierGlows(IClientEntity* entity);
 	void DemoGlows(IClientEntity* entity);
 
-	CHandle<C_BaseEntity> CreateGlowForEntity(IClientEntity* ent);
+	void CreateGlowForEntity(IClientEntity* ent);
 	std::unordered_map<int, CHandle<C_BaseEntity>> m_GlowEntities;
 
 	// Some random numbers I generated

--- a/CastingEssentials/Modules/ProjectileOutlines.h
+++ b/CastingEssentials/Modules/ProjectileOutlines.h
@@ -39,6 +39,7 @@ private:
 
 	void SoldierGlows(IClientEntity* entity);
 	void DemoGlows(IClientEntity* entity);
+	Color CalcProjectileColor(IClientEntity* baseEntity, IClientEntity* glowEntity);
 
 	void CreateGlowForEntity(IClientEntity* ent);
 	std::unordered_map<int, CHandle<C_BaseEntity>> m_GlowEntities;


### PR DESCRIPTION
When projectiles are deflected, their team is switched and thus their
color should too. The game updates the projectile team for us, so we can
just recalculate the color on-the-fly to pick up the new color.

We don't bother caching the old team name and checking for changes and
so on - there are not that many projectiles on the map at any one time
to actually make it a significant performance bottleneck.

This fixes #84.

I've also made a tiny code cleanup in the same module.