### PR TITLE
Add SrcTV+ detection module

### DIFF
--- a/CastingEssentials/CastingEssentials.vcxproj
+++ b/CastingEssentials/CastingEssentials.vcxproj
@@ -121,6 +121,7 @@
     <ClCompile Include="Modules\ProjectileOutlines.cpp" />
     <ClCompile Include="Modules\FreezeInfo.cpp" />
     <ClCompile Include="Modules\SniperLOS.cpp" />
+    <ClCompile Include="Modules\SrcTVPlus.cpp" />
     <ClCompile Include="Modules\SteamTools.cpp" />
     <ClCompile Include="Modules\TeamNames.cpp" />
     <ClCompile Include="Modules\IngameTeamScores.cpp" />
@@ -185,6 +186,7 @@
     <ClInclude Include="Modules\PlayerAliases.h" />
     <ClInclude Include="Modules\ProjectileOutlines.h" />
     <ClInclude Include="Modules\SniperLOS.h" />
+    <ClInclude Include="Modules\SrcTVPlus.h" />
     <ClInclude Include="Modules\SteamTools.h" />
     <ClInclude Include="Modules\TeamNames.h" />
     <ClInclude Include="Modules\IngameTeamScores.h" />

--- a/CastingEssentials/CastingEssentials.vcxproj.filters
+++ b/CastingEssentials/CastingEssentials.vcxproj.filters
@@ -174,6 +174,9 @@
     <ClCompile Include="PluginBase\PlayerStateBase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\SrcTVPlus.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="PluginBase\Plugin.h">
@@ -381,6 +384,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Misc\SuggestionList.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\SrcTVPlus.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/CastingEssentials/Modules/SrcTVPlus.cpp
+++ b/CastingEssentials/Modules/SrcTVPlus.cpp
@@ -1,0 +1,70 @@
+#include <Modules/SrcTVPlus.h>
+#include <PluginBase/VariablePusher.h>
+#include <PluginBase/Interfaces.h>
+#include <client/c_baseentity.h>
+#include <client/c_baseplayer.h>
+#include <toolframework/ienginetool.h>
+#include <set>
+
+MODULE_REGISTER(SrcTVPlus);
+
+bool SrcTVPlus::s_Detected = false;
+std::map<int, std::function<SrcTVPlus::Callback>> SrcTVPlus::s_Listeners;
+int SrcTVPlus::s_MaxListener = 0;
+
+void SrcTVPlus::NotifyListeners() {
+	for (auto& listener : s_Listeners)
+		listener.second(s_Detected);
+}
+void SrcTVPlus::SetDetected(bool value, bool force_broadcast) {
+	if (!force_broadcast && value == s_Detected) return; // In general, don't re-send but we need it for initial load
+	s_Detected = value;
+	NotifyListeners();
+}
+
+static RecvProp* g_Prop = nullptr;
+static VariablePusher<RecvVarProxyFn> g_ProxyPusher;
+static std::map<int, int> g_SeenEntities; // Entity ID + serial -> number of times seen
+
+void SrcTVPlus::DetectorProxy(const CRecvProxyData *pData, void *pStruct, void *pOut) {
+	auto ent = static_cast<C_BasePlayer*>(pStruct);
+	if(ent != C_BasePlayer::GetLocalPlayer()) {
+		auto id = ent->GetRefEHandle().ToInt();
+		if (++g_SeenEntities[id] >= 10) {
+			SrcTVPlus::DisableDetector();
+			PluginMsg("SrcTV+ detected\n");
+			SrcTVPlus::SetDetected(true);
+		}
+	}
+	g_ProxyPusher.GetOldValue()(pData, pStruct, pOut);
+}
+
+bool SrcTVPlus::CheckDependencies()
+{
+	auto tbl = const_cast<RecvTable*>(Entities::FindRecvTable("DT_LocalPlayerExclusive"));
+	if (!tbl) {
+		PluginWarning("Required data table DT_LocalPlayerExclusive for module %s not found!\n", GetModuleName());
+		return false;
+	}
+	g_Prop = Entities::FindRecvProp(tbl, "m_nTickBase");
+	if (!g_Prop) {
+		PluginWarning("Required recv prop DT_LocalPlayerExclusive.m_nTickBase for module %s not found!\n", GetModuleName());
+		return false;
+	}
+
+	return true;
+}
+
+void SrcTVPlus::EnableDetector()
+{
+	if (s_Detected) return; // Already detected, no need to enable
+	if (!g_ProxyPusher.IsEmpty()) return; // Already enabled
+	g_SeenEntities.clear();
+	g_ProxyPusher = CreateVariablePusher(g_Prop->m_ProxyFn, &DetectorProxy);
+}
+
+void SrcTVPlus::DisableDetector()
+{
+	g_ProxyPusher.Clear();
+	g_SeenEntities.clear();
+}

--- a/CastingEssentials/Modules/SrcTVPlus.h
+++ b/CastingEssentials/Modules/SrcTVPlus.h
@@ -1,0 +1,77 @@
+#pragma once
+#pragma once
+
+#include "PluginBase/Modules.h"
+#include "PluginBase/Entities.h"
+#include <map>
+
+class SrcTVPlusListener;
+class CRecvProxyData;
+
+// Detects the presence of SrcTV+(or equivalent)
+//
+// Other modules can use this to figure out if they should show extra information based
+// on the presence of SrcTV+ or an equivalent plugin. They should not declare a dependency
+// on this module, but rather use the `IsAvailable()` and `SrcTVPlusListener`. The former
+// allows checking if SrcTV+ is available, the latter allows listener for it becoming
+// (un)available.
+//
+// All of the members related to interfacing with other modules is static. This is for both
+// performance but also robustness. Should SrcTV+ detection fail for any reason, the static
+// members will continue to work and act as if SrcTV+ is disabled.
+
+class SrcTVPlus : public Module<SrcTVPlus>
+{
+public:
+	__forceinline static bool IsAvailable() { return s_Detected; }
+	using Callback = void(bool);
+
+protected:
+
+	template<typename F> static int register_listener(F&& cb) {
+		auto id = s_MaxListener++;
+		s_Listeners.emplace(id, std::forward<F>(cb));
+		cb(s_Detected); // Call with current value
+		return id;
+	}
+	static void unregister_listener(int id) {
+		s_Listeners.erase(id);
+	}
+	friend class SrcTVPlusListener;
+
+// Module implementation
+public:
+	static bool CheckDependencies();
+	static constexpr __forceinline const char* GetModuleName() { return "SrcTV+ detection"; }
+
+protected:
+	// When entering/leaving a level we reset the detector
+	virtual void LevelInit() { SetDetected(false, true); EnableDetector(); }
+	virtual void LevelShutdown() { SetDetected(false); DisableDetector(); }
+
+	static void EnableDetector();
+	static void DisableDetector();
+	static void DetectorProxy(const CRecvProxyData *pData, void *pStruct, void *pOut);
+
+private:
+	static bool s_Detected;
+	static std::map<int, std::function<Callback>> s_Listeners;
+	static int s_MaxListener;
+
+	static void NotifyListeners();
+	static void SetDetected(bool value, bool force_broadcast = false);
+};
+
+class SrcTVPlusListener
+{
+public:
+	template<typename F> SrcTVPlusListener(F&& cb) {
+		m_ListenerID = SrcTVPlus::register_listener(std::forward<F>(cb));
+	}
+	SrcTVPlusListener() {
+		SrcTVPlus::unregister_listener(m_ListenerID);
+	}
+
+private:
+	int m_ListenerID;
+};


### PR DESCRIPTION
This module is designed for progressive enhancement with
[srctv+](https://github.com/dalegaard/srctvplus) or an equivalent server
plugin(or a future TF2 update).

Normally SourceTV will not send player- and weaponlocal data, as well as
leaving out many relevant game events like `player_hurt` and
`player_healed`. The SrcTV+ server plugin makes it send everything.

For CE to support servers both with and without SrcTV+(both dedicated
and listen servers) we need to be able to detect the presence of the
server plugin. This is what this module does.

Other modules can query the status via the `SrcTVPlus::IsAvailable()`
call, and they can subscribe to status updates using the
`SrcTVPlusListener` class.

Internally detection works by replacing the receive proxy for the
`DT_LocalPlayerExclusive.m_nTickBase` field with a hook. This field,
like the rest of `DT_LocalPlayerExclusive` is normally only sent to the
local player, so we can simply look for updates to it to determine if
SrcTV+ is available. Note however, when the game spawns an entity the
receive proxy is called, sometimes multiple times, for the new entity
and thus we need to look for at least a few updates. We've chosen 10 as
a somewhat arbitrary cutoff point, to balance detection speed with
robustness.

This fixes #87.