### PR TITLE
Execute castingessentials.cfg after load

### DIFF
--- a/CastingEssentials/PluginBase/CastingPlugin.cpp
+++ b/CastingEssentials/PluginBase/CastingPlugin.cpp
@@ -53,6 +53,8 @@ bool CastingPlugin::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceFn g
 	const auto delta = std::chrono::duration<float>(endTime - startTime);
 	PluginMsg("Finished loading %d modules in %1.2f seconds.\n", Modules().size(), delta.count());
 
+	Interfaces::GetEngineClient()->ExecuteClientCmd("exec castingessentials.cfg");
+
 	return true;
 }
 


### PR DESCRIPTION
After `CastingPlugin::Load` finishes, we'll now execute a CE specific
config, `castingessentials.cfg`. This gives users a logical place to put
their CE related config options.