### PR TITLE
Added `ce_hitevents_healing_crossbow_only`

### DIFF
--- a/CastingEssentials/Modules/HitEvents.h
+++ b/CastingEssentials/Modules/HitEvents.h
@@ -30,6 +30,7 @@ protected:
 
 private:
 	std::vector<IGameEvent*> m_EventsToIgnore;
+	CDamageAccountPanel* m_Panel { nullptr };
 
 	void UpdateEnabledState();
 
@@ -48,4 +49,5 @@ private:
 
 	ConVar ce_hitevents_enabled;
 	ConVar ce_hitevents_dmgnumbers_los;
+	ConVar ce_hitevents_healing_crossbow_only;
 };


### PR DESCRIPTION
When broadcasting, showing all healing events in combattext doesn't look
particularly good. `ce_hitevents_healing_crossbow_only` stops the combat
text from showing `player_healed` events, but instead shows all
`crossbow_heal` events as if they were `player_healed` events.

Because we are hooking the `FireGameEvent` method on the
CDamageAccountPanel, we wouldn't normally receive `crossbow_heal`
events. We utilize our hook on `CDamageAccountPanel::ShouldDraw` to
catch the first invocation on a given `CDamageAccountPanel` instance and
subscribe to the event here.

We then add relevant checks and paths in our `FireGameEvent` hook. When
we encounter a `crossbow_heal` event, and crossbow-only mode is set, we
create a new `player_healed` event with matching data and send this to
the original `CDamageAccountPanel::FireGameEvent` method.